### PR TITLE
Listen on loopback and protect against CSRF

### DIFF
--- a/templates/default.html
+++ b/templates/default.html
@@ -9,6 +9,7 @@
 			{
 				var xmlHttp = new XMLHttpRequest();
 				xmlHttp.open( "POST", location.href + 'run/' + URL, false ); // false for synchronous request
+				xmlHttp.setRequestHeader("X-CSRF-Token", "{{.CSRFToken}}" );
 				xmlHttp.send( null );
 				return xmlHttp.responseText;
 			}


### PR DESCRIPTION
- Change listen address to "localhost" to prevent users on LAN from
sending arbitrary commands to your PC

- Use gorilla/csrf to prevent links in web pages (or redirects) from
triggering arbitrary commands on your PC